### PR TITLE
Camelcase names

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ improvements we could make. _All naming subject to bike shedding._
 - `ext`: Traditional (pre TS 5) extension naming with `*.css.d.ts`
 - `ignore`: Ignore support
 - `format`: Class name formatting
-  - (Related) Gracefully handle invalid names (example: kebab case)
 - `outDir`: Publish to a directory instead of next to the sources
 - `watch`: First-class watch mode
 - General CLI/UX improvements

--- a/main.js
+++ b/main.js
@@ -42,7 +42,8 @@ async function generateDeclaration(path, time) {
 	const ast = parseCss(css, { filename: path });
 	walk(ast, (node) => {
 		if (node.type === `ClassSelector`) {
-			ts += `export const ${node.name}: string;\n`;
+			let cs = camelCase(node.name);
+			ts += `export const ${cs}: string;\n`;
 		}
 	});
 
@@ -53,4 +54,30 @@ async function generateDeclaration(path, time) {
 function dtsPath(path) {
 	const { dir, name, ext } = parsePath(path);
 	return join(dir, `${name}.d${ext}.ts`);
+}
+
+// The same camelCase function from css-loader that is used to provide
+// the class selector names to Gatsby.
+function camelCase(input) {
+  let result = input.trim();
+
+  if (result.length === 0) {
+    return "";
+  }
+
+  if (result.length === 1) {
+    return result.toLowerCase();
+  }
+
+  const hasUpperCase = result !== result.toLowerCase();
+
+  if (hasUpperCase) {
+    result = preserveCamelCase(result);
+  }
+
+  return result
+    .replace(/^[_.\- ]+/, "")
+    .toLowerCase()
+    .replace(/[_.\- ]+([\p{Alpha}\p{N}_]|$)/gu, (_, p1) => p1.toUpperCase())
+    .replace(/\d+([\p{Alpha}\p{N}_]|$)/gu, (m) => m.toUpperCase());
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -328,18 +328,18 @@
 			}
 		},
 		"node_modules/glob": {
-			"version": "10.3.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.3.4.tgz",
-			"integrity": "sha512-6LFElP3A+i/Q8XQKEvZjkEWEOTgAIALR9AO2rwT8bgPhDd1anmqDJDZ6lLddI4ehxxxR1S5RIqKe1uapMQfYaQ==",
+			"version": "10.3.10",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+			"integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
 			"dependencies": {
 				"foreground-child": "^3.1.0",
-				"jackspeak": "^2.0.3",
+				"jackspeak": "^2.3.5",
 				"minimatch": "^9.0.1",
 				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
 				"path-scurry": "^1.10.1"
 			},
 			"bin": {
-				"glob": "dist/cjs/src/bin.js"
+				"glob": "dist/esm/bin.mjs"
 			},
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -423,9 +423,9 @@
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
 		},
 		"node_modules/jackspeak": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.3.tgz",
-			"integrity": "sha512-R2bUw+kVZFS/h1AZqBKrSgDmdmjApzgY0AlCPumopFiAlbUxE2gf+SCuBzQ0cP5hHmUmFYF5yw55T97Th5Kstg==",
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
+			"integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
 			"dependencies": {
 				"@isaacs/cliui": "^8.0.2"
 			},


### PR DESCRIPTION
This uses the logic from [css-loader](https://github.com/webpack-contrib/css-loader) that Gastby uses for converting invalid names to camelcase.

I had to first update the `glob` dependency to the newer ESM version so that I could test it in my environment. I've included that commit in this pull request as well.

With this change processing
```css
.container {
  margin: auto;
  max-width: 500px;
  font-family: sans-serif;
}

.heading {
  color: rebeccapurple;
}
.nav-links {
  display: flex;
  list-style: none;
  padding-left: 0;
}
.nav-link-item {
  padding-right: 2rem;
}
.nav-link-text {
  color: black;
}
```

produces
```typescript
// Generated from src/components/layout.module.css by css-typed at 2023-10-07T12:16:44.347Z

export const container: string;
export const heading: string;
export const navLinks: string;
export const navLinkItem: string;
export const navLinkText: string;
```

instead of the invalid
```typescript
// Generated from src/components/layout.module.css by css-typed at 2023-10-07T12:16:44.347Z

export const container: string;
export const heading: string;
export const nav-links: string;
export const nav-link-item: string;
export const nav-link-text: string;
```