### PR TITLE
✨ Add package.json entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,5 +59,6 @@
 		"npm-run-all": "^4.1.5",
 		"prettier": "^3.3.3",
 		"vitest": "^2.0.4"
-	}
+	},
+	"main": "dist/main.js"
 }


### PR DESCRIPTION
Adds `main` entry point in `package.json` per request. This should allow Bundlephobia to scan the package.

Closes #13.