### PR TITLE
✨ Output directory option

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -94,7 +94,7 @@ jobs:
           diff --strip-trailing-cr -uI '//.*' src/fixtures/casing/camelCaseOnly.d.css.ts "$RUNNER_TEMP/casing.d.css.ts"
 
           ./dist/main.js "$RUNNER_TEMP/*.css" --outdir gen1
-          diff --strip-trailing-cr -uI '//.*' src/fixtures/casing/dashesOnly.d.css.ts "$RUNNER_TEMP/gen1/casing.d.css.ts"
+          diff --strip-trailing-cr -uI '//.*' src/fixtures/casing/dashesOnly.d.css.ts "gen1/casing.d.css.ts"
 
           ./dist/main.js "$RUNNER_TEMP/*.css" -o $RUNNER_TEMP/gen2
           diff --strip-trailing-cr -uI '//.*' src/fixtures/casing/dashesOnly.d.css.ts "$RUNNER_TEMP/gen2/casing.d.css.ts"

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -93,6 +93,9 @@ jobs:
           node dist/main.js --localsConvention camelCaseOnly "$RUNNER_TEMP/*.css"
           diff --strip-trailing-cr -uI '//.*' src/fixtures/casing/camelCaseOnly.d.css.ts "$RUNNER_TEMP/casing.d.css.ts"
 
+          node dist/main.js "$RUNNER_TEMP/*.css" -o "$RUNNER_TEMP/generated"
+          diff --strip-trailing-cr -uI '//.*' src/fixtures/casing/dashesOnly.d.css.ts "$RUNNER_TEMP/generated/casing.d.css.ts"
+
   Publish:
     if: ${{ github.ref == 'refs/heads/main' }}
     name: Publish

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -93,7 +93,7 @@ jobs:
           node dist/main.js --localsConvention camelCaseOnly "$RUNNER_TEMP/*.css"
           diff --strip-trailing-cr -uI '//.*' src/fixtures/casing/camelCaseOnly.d.css.ts "$RUNNER_TEMP/casing.d.css.ts"
 
-          node dist/main.js "$RUNNER_TEMP/*.css" -o "$RUNNER_TEMP/generated"
+          node dist/main.js "$RUNNER_TEMP/*.css" -o generated
           diff --strip-trailing-cr -uI '//.*' src/fixtures/casing/dashesOnly.d.css.ts "$RUNNER_TEMP/generated/casing.d.css.ts"
 
   Publish:

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -93,11 +93,11 @@ jobs:
           ./dist/main.js --localsConvention camelCaseOnly "$RUNNER_TEMP/*.css"
           diff --strip-trailing-cr -uI '//.*' src/fixtures/casing/camelCaseOnly.d.css.ts "$RUNNER_TEMP/casing.d.css.ts"
 
-          ./dist/main.js "$RUNNER_TEMP/*.css" --outdir gen1
-          diff --strip-trailing-cr -uI '//.*' src/fixtures/casing/dashesOnly.d.css.ts "gen1/casing.d.css.ts"
+          ./dist/main.js "$RUNNER_TEMP/*.css" --outdir generated
+          diff --strip-trailing-cr -uI '//.*' src/fixtures/casing/dashesOnly.d.css.ts "generated/casing.d.css.ts"
 
-          ./dist/main.js "$RUNNER_TEMP/*.css" -o $RUNNER_TEMP/gen2
-          diff --strip-trailing-cr -uI '//.*' src/fixtures/casing/dashesOnly.d.css.ts "$RUNNER_TEMP/gen2/casing.d.css.ts"
+          ./dist/main.js "$RUNNER_TEMP/*.css" -o $RUNNER_TEMP/generated
+          diff --strip-trailing-cr -uI '//.*' src/fixtures/casing/dashesOnly.d.css.ts "$RUNNER_TEMP/generated/casing.d.css.ts"
 
   Publish:
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -84,17 +84,20 @@ jobs:
         run: |
           cp src/fixtures/casing/casing.css "$RUNNER_TEMP/casing.css"
 
-          node dist/main.js "$RUNNER_TEMP/*.css"
+          ./dist/main.js "$RUNNER_TEMP/*.css"
           diff --strip-trailing-cr -uI '//.*' src/fixtures/casing/dashesOnly.d.css.ts "$RUNNER_TEMP/casing.d.css.ts"
 
-          node dist/main.js "$RUNNER_TEMP/*.css" --localsConvention camelCaseOnly
+          ./dist/main.js "$RUNNER_TEMP/*.css" --localsConvention camelCaseOnly
           diff --strip-trailing-cr -uI '//.*' src/fixtures/casing/camelCaseOnly.d.css.ts "$RUNNER_TEMP/casing.d.css.ts"
 
-          node dist/main.js --localsConvention camelCaseOnly "$RUNNER_TEMP/*.css"
+          ./dist/main.js --localsConvention camelCaseOnly "$RUNNER_TEMP/*.css"
           diff --strip-trailing-cr -uI '//.*' src/fixtures/casing/camelCaseOnly.d.css.ts "$RUNNER_TEMP/casing.d.css.ts"
 
-          node dist/main.js "$RUNNER_TEMP/*.css" -o generated
-          diff --strip-trailing-cr -uI '//.*' src/fixtures/casing/dashesOnly.d.css.ts "$RUNNER_TEMP/generated/casing.d.css.ts"
+          ./dist/main.js "$RUNNER_TEMP/*.css" --outdir gen1
+          diff --strip-trailing-cr -uI '//.*' src/fixtures/casing/dashesOnly.d.css.ts "$RUNNER_TEMP/gen1/casing.d.css.ts"
+
+          ./dist/main.js "$RUNNER_TEMP/*.css" -o $RUNNER_TEMP/gen2
+          diff --strip-trailing-cr -uI '//.*' src/fixtures/casing/dashesOnly.d.css.ts "$RUNNER_TEMP/gen2/casing.d.css.ts"
 
   Publish:
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -82,22 +82,23 @@ jobs:
         # Use `-I '//.*'` to ignore the first line (comment) which has generated path and timestamp
         # Test `--localsConvention` in both positions
         run: |
-          cp src/fixtures/casing/casing.css "$RUNNER_TEMP/casing.css"
+          cp $GITHUB_WORKSPACE/src/fixtures/casing/casing.css casing.css
 
-          ./dist/main.js "$RUNNER_TEMP/*.css"
-          diff --strip-trailing-cr -uI '//.*' src/fixtures/casing/dashesOnly.d.css.ts "$RUNNER_TEMP/casing.d.css.ts"
+          ./dist/main.js "*.css"
+          diff --strip-trailing-cr -uI '//.*' $GITHUB_WORKSPACE/src/fixtures/casing/dashesOnly.d.css.ts casing.d.css.ts
 
-          ./dist/main.js "$RUNNER_TEMP/*.css" --localsConvention camelCaseOnly
-          diff --strip-trailing-cr -uI '//.*' src/fixtures/casing/camelCaseOnly.d.css.ts "$RUNNER_TEMP/casing.d.css.ts"
+          ./dist/main.js "*.css" --localsConvention camelCaseOnly
+          diff --strip-trailing-cr -uI '//.*' $GITHUB_WORKSPACE/src/fixtures/casing/camelCaseOnly.d.css.ts casing.d.css.ts
 
-          ./dist/main.js --localsConvention camelCaseOnly "$RUNNER_TEMP/*.css"
-          diff --strip-trailing-cr -uI '//.*' src/fixtures/casing/camelCaseOnly.d.css.ts "$RUNNER_TEMP/casing.d.css.ts"
+          ./dist/main.js --localsConvention camelCaseOnly "*.css"
+          diff --strip-trailing-cr -uI '//.*' $GITHUB_WORKSPACE/src/fixtures/casing/camelCaseOnly.d.css.ts casing.d.css.ts
 
-          ./dist/main.js "$RUNNER_TEMP/*.css" --outdir generated
-          diff --strip-trailing-cr -uI '//.*' src/fixtures/casing/dashesOnly.d.css.ts "generated/casing.d.css.ts"
+          ./dist/main.js "*.css" --outdir generated
+          diff --strip-trailing-cr -uI '//.*' $GITHUB_WORKSPACE/src/fixtures/casing/dashesOnly.d.css.ts generated/casing.d.css.ts
 
-          ./dist/main.js "$RUNNER_TEMP/*.css" -o $RUNNER_TEMP/generated
-          diff --strip-trailing-cr -uI '//.*' src/fixtures/casing/dashesOnly.d.css.ts "$RUNNER_TEMP/generated/casing.d.css.ts"
+          ./dist/main.js "*.css" -o $GITHUB_WORKSPACE/generated
+          diff --strip-trailing-cr -uI '//.*' $GITHUB_WORKSPACE/src/fixtures/casing/dashesOnly.d.css.ts $GITHUB_WORKSPACE/generated/casing.d.css.ts
+        working-directory: $RUNNER_TEMP
 
   Publish:
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -77,28 +77,58 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Run css-typed (the test)
-        # `node dist/main.js` is executing local `css-typed` as if installed (same as `bin`)
-        # Use `-I '//.*'` to ignore the first line (comment) which has generated path and timestamp
-        # Test `--localsConvention` in both positions
+      # Run tests
+      #
+      # - Run from $RUNNER_TEMP for auto-cleanup.
+      # - `./dist/main.js` is executing local `css-typed` as if installed (same as `bin`).
+      #   But it is `$GITHUB_WORKSPACE/dist/main.js` b/c we `cd $RUNNER_TEMP`.
+      # - Use `diff` to compare the files.
+      #   Use `-I '//.*'` to ignore the first line (comment) which has generated path and timestamp.
+
+      - name: "Test 1: Default case"
         run: |
+          cp src/fixtures/casing/casing.css $RUNNER_TEMP/casing.css
+          cp src/fixtures/casing/dashesOnly.d.css.ts $RUNNER_TEMP/expected.d.css.ts
+
           cd $RUNNER_TEMP
-          cp $GITHUB_WORKSPACE/src/fixtures/casing/casing.css casing.css
+          $GITHUB_WORKSPACE/dist/main.js '*.css'
+          diff --strip-trailing-cr -uI '//.*' expected.d.css.ts casing.d.css.ts
 
-          $GITHUB_WORKSPACE/dist/main.js "*.css"
-          diff --strip-trailing-cr -uI '//.*' $GITHUB_WORKSPACE/src/fixtures/casing/dashesOnly.d.css.ts casing.d.css.ts
+      - name: "Test 2: localsConvention, second position"
+        run: |
+          cp src/fixtures/casing/casing.css $RUNNER_TEMP/casing.css
+          cp src/fixtures/casing/camelCaseOnly.d.css.ts $RUNNER_TEMP/expected.d.css.ts
 
-          $GITHUB_WORKSPACE/dist/main.js "*.css" --localsConvention camelCaseOnly
-          diff --strip-trailing-cr -uI '//.*' $GITHUB_WORKSPACE/src/fixtures/casing/camelCaseOnly.d.css.ts casing.d.css.ts
+          cd $RUNNER_TEMP
+          $GITHUB_WORKSPACE/dist/main.js '*.css' --localsConvention camelCaseOnly
+          diff --strip-trailing-cr -uI '//.*' expected.d.css.ts casing.d.css.ts
 
-          $GITHUB_WORKSPACE/dist/main.js --localsConvention camelCaseOnly "*.css"
-          diff --strip-trailing-cr -uI '//.*' $GITHUB_WORKSPACE/src/fixtures/casing/camelCaseOnly.d.css.ts casing.d.css.ts
+      - name: "Test 3: localsConvention, first position"
+        run: |
+          cp src/fixtures/casing/casing.css $RUNNER_TEMP/casing.css
+          cp src/fixtures/casing/camelCaseOnly.d.css.ts $RUNNER_TEMP/expected.d.css.ts
 
-          $GITHUB_WORKSPACE/dist/main.js "*.css" --outdir generated
-          diff --strip-trailing-cr -uI '//.*' $GITHUB_WORKSPACE/src/fixtures/casing/dashesOnly.d.css.ts generated/casing.d.css.ts
+          cd $RUNNER_TEMP
+          $GITHUB_WORKSPACE/dist/main.js --localsConvention camelCaseOnly '*.css'
+          diff --strip-trailing-cr -uI '//.*' expected.d.css.ts casing.d.css.ts
 
-          $GITHUB_WORKSPACE/dist/main.js "*.css" -o $GITHUB_WORKSPACE/generated
-          diff --strip-trailing-cr -uI '//.*' $GITHUB_WORKSPACE/src/fixtures/casing/dashesOnly.d.css.ts $GITHUB_WORKSPACE/generated/casing.d.css.ts
+      - name: "Test 4: relative outdir"
+        run: |
+          cp src/fixtures/casing/casing.css $RUNNER_TEMP/casing.css
+          cp src/fixtures/casing/dashesOnly.d.css.ts $RUNNER_TEMP/expected.d.css.ts
+
+          cd $RUNNER_TEMP
+          $GITHUB_WORKSPACE/dist/main.js '*.css' --outdir generated
+          diff --strip-trailing-cr -uI '//.*' expected.d.css.ts generated/casing.d.css.ts
+
+      - name: "Test 5: absolute outdir"
+        run: |
+          cp src/fixtures/casing/casing.css $RUNNER_TEMP/casing.css
+          cp src/fixtures/casing/dashesOnly.d.css.ts $RUNNER_TEMP/expected.d.css.ts
+
+          cd $RUNNER_TEMP
+          $GITHUB_WORKSPACE/dist/main.js '*.css' -o $GITHUB_WORKSPACE/generated
+          diff --strip-trailing-cr -uI '//.*' expected.d.css.ts $GITHUB_WORKSPACE/generated/casing.d.css.ts
 
   Publish:
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -85,19 +85,19 @@ jobs:
           cd $RUNNER_TEMP
           cp $GITHUB_WORKSPACE/src/fixtures/casing/casing.css casing.css
 
-          ./dist/main.js "*.css"
+          $GITHUB_WORKSPACE/dist/main.js "*.css"
           diff --strip-trailing-cr -uI '//.*' $GITHUB_WORKSPACE/src/fixtures/casing/dashesOnly.d.css.ts casing.d.css.ts
 
-          ./dist/main.js "*.css" --localsConvention camelCaseOnly
+          $GITHUB_WORKSPACE/dist/main.js "*.css" --localsConvention camelCaseOnly
           diff --strip-trailing-cr -uI '//.*' $GITHUB_WORKSPACE/src/fixtures/casing/camelCaseOnly.d.css.ts casing.d.css.ts
 
-          ./dist/main.js --localsConvention camelCaseOnly "*.css"
+          $GITHUB_WORKSPACE/dist/main.js --localsConvention camelCaseOnly "*.css"
           diff --strip-trailing-cr -uI '//.*' $GITHUB_WORKSPACE/src/fixtures/casing/camelCaseOnly.d.css.ts casing.d.css.ts
 
-          ./dist/main.js "*.css" --outdir generated
+          $GITHUB_WORKSPACE/dist/main.js "*.css" --outdir generated
           diff --strip-trailing-cr -uI '//.*' $GITHUB_WORKSPACE/src/fixtures/casing/dashesOnly.d.css.ts generated/casing.d.css.ts
 
-          ./dist/main.js "*.css" -o $GITHUB_WORKSPACE/generated
+          $GITHUB_WORKSPACE/dist/main.js "*.css" -o $GITHUB_WORKSPACE/generated
           diff --strip-trailing-cr -uI '//.*' $GITHUB_WORKSPACE/src/fixtures/casing/dashesOnly.d.css.ts $GITHUB_WORKSPACE/generated/casing.d.css.ts
 
   Publish:

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -82,6 +82,7 @@ jobs:
         # Use `-I '//.*'` to ignore the first line (comment) which has generated path and timestamp
         # Test `--localsConvention` in both positions
         run: |
+          cd $RUNNER_TEMP
           cp $GITHUB_WORKSPACE/src/fixtures/casing/casing.css casing.css
 
           ./dist/main.js "*.css"
@@ -98,7 +99,6 @@ jobs:
 
           ./dist/main.js "*.css" -o $GITHUB_WORKSPACE/generated
           diff --strip-trailing-cr -uI '//.*' $GITHUB_WORKSPACE/src/fixtures/casing/dashesOnly.d.css.ts $GITHUB_WORKSPACE/generated/casing.d.css.ts
-        working-directory: $RUNNER_TEMP
 
   Publish:
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/src/logic.test.ts
+++ b/src/logic.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
+import * as process from "node:process";
 
 import { describe, expect, it } from "vitest";
 
@@ -37,14 +38,21 @@ describe(`css-typed`, () => {
 		});
 	});
 
+	const cwd = process.cwd();
+	const cwdParent = path.resolve(cwd, `..`);
 	describe(`dtsPath`, () => {
 		it.each([
-			[`foo.css`, undefined, `foo.d.css.ts`],
-			[`foo.module.css`, undefined, `foo.module.d.css.ts`],
-			[`src/bar/foo.css`, `generated`, `generated/src/bar/foo.d.css.ts`],
-		])(`%s should create file %s`, (input, outdir, expected) => {
-			expect(dtsPath(input, outdir)).toStrictEqual(expected);
-		});
+			[`src/foo.css`, `${cwd}/src/foo.d.css.ts`, undefined],
+			[`src/foo.module.css`, `${cwd}/src/foo.module.d.css.ts`, ``],
+			[`src/foo.css`, `${cwd}/generated/src/foo.d.css.ts`, `generated`],
+			[`src/foo.css`, `/absolute/src/foo.d.css.ts`, `/absolute`],
+			[`src/foo.css`, `${cwdParent}/relative/src/foo.d.css.ts`, `../relative`],
+		])(
+			`[%s] should create file [%s] with outdir [%s]`,
+			(input, expected, outdir) => {
+				expect(dtsPath(input, outdir)).toStrictEqual(expected);
+			},
+		);
 	});
 });
 

--- a/src/logic.test.ts
+++ b/src/logic.test.ts
@@ -50,7 +50,7 @@ describe(`css-typed`, () => {
 		])(
 			`[%s] should create file [%s] with outdir [%s]`,
 			(input, expected, outdir) => {
-				expect(dtsPath(input, outdir)).toStrictEqual(expected);
+				expect(path.join(...dtsPath(input, outdir))).toStrictEqual(expected);
 			},
 		);
 	});

--- a/src/logic.test.ts
+++ b/src/logic.test.ts
@@ -39,10 +39,11 @@ describe(`css-typed`, () => {
 
 	describe(`dtsPath`, () => {
 		it.each([
-			[`foo.css`, `foo.d.css.ts`],
-			[`foo.module.css`, `foo.module.d.css.ts`],
-		])(`%s should create file %s`, (input, expected) => {
-			expect(dtsPath(input)).toStrictEqual(expected);
+			[`foo.css`, undefined, `foo.d.css.ts`],
+			[`foo.module.css`, undefined, `foo.module.d.css.ts`],
+			[`src/bar/foo.css`, `generated`, `generated/src/bar/foo.d.css.ts`],
+		])(`%s should create file %s`, (input, outdir, expected) => {
+			expect(dtsPath(input, outdir)).toStrictEqual(expected);
 		});
 	});
 });

--- a/src/logic.ts
+++ b/src/logic.ts
@@ -154,7 +154,10 @@ function dashesCamelCase(s: string) {
 	);
 }
 
-export function dtsPath(stylesheetPath: string, outdir: string | undefined) {
+export function dtsPath(
+	stylesheetPath: string,
+	outdir: string | undefined,
+): [string, string] {
 	const { dir: originalDirectory, name, ext } = path.parse(stylesheetPath);
 
 	let directory;
@@ -165,5 +168,5 @@ export function dtsPath(stylesheetPath: string, outdir: string | undefined) {
 		directory = originalDirectory;
 	}
 
-	return path.join(path.resolve(directory), `${name}.d${ext}.ts`);
+	return [path.resolve(directory), `${name}.d${ext}.ts`];
 }

--- a/src/logic.ts
+++ b/src/logic.ts
@@ -165,5 +165,5 @@ export function dtsPath(stylesheetPath: string, outdir: string | undefined) {
 		directory = originalDirectory;
 	}
 
-	return path.join(directory, `${name}.d${ext}.ts`);
+	return path.join(path.resolve(directory), `${name}.d${ext}.ts`);
 }

--- a/src/logic.ts
+++ b/src/logic.ts
@@ -154,7 +154,16 @@ function dashesCamelCase(s: string) {
 	);
 }
 
-export function dtsPath(stylesheetPath: string) {
-	const { dir, name, ext } = path.parse(stylesheetPath);
-	return path.join(dir, `${name}.d${ext}.ts`);
+export function dtsPath(stylesheetPath: string, outdir: string | undefined) {
+	const { dir: originalDirectory, name, ext } = path.parse(stylesheetPath);
+
+	let directory;
+	if (outdir) {
+		const relative = path.relative(process.cwd(), originalDirectory);
+		directory = path.join(outdir, relative);
+	} else {
+		directory = originalDirectory;
+	}
+
+	return path.join(directory, `${name}.d${ext}.ts`);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
-import { writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
 
 import { Command, Option } from "@commander-js/extra-typings";
 import { glob } from "glob";
@@ -55,7 +57,15 @@ async function writeDeclarationFile(
 	outdir: string | undefined,
 	ts: string | undefined,
 ) {
-	if (!ts) return undefined;
-	await writeFile(dtsPath(file, outdir), ts, `utf8`);
-	return undefined;
+	if (!ts) {
+		return undefined;
+	}
+
+	const [directoryToWrite, fileToWrite] = dtsPath(file, outdir);
+	if (!existsSync(directoryToWrite)) {
+		await mkdir(directoryToWrite, { recursive: true });
+	}
+
+	const pathToWrite = path.join(directoryToWrite, fileToWrite);
+	await writeFile(pathToWrite, ts, { encoding: `utf8` });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,10 @@ await new Command()
 			.choices(localsConventionChoices)
 			.default(`dashesOnly` as const),
 	)
+	.option(
+		`-o, --outdir <outDirectory>`,
+		`Root directory for generated CSS declaration files.`,
+	)
 	.action(async function (pattern, options) {
 		const files = await glob(pattern);
 
@@ -29,7 +33,7 @@ await new Command()
 		await Promise.all(
 			files.map((file) =>
 				generateDeclaration(file, time, options).then((ts) =>
-					writeDeclarationFile(file, ts),
+					writeDeclarationFile(file, options.outdir, ts),
 				),
 			),
 		);
@@ -39,12 +43,17 @@ await new Command()
 /**
  * Writes the TypeScript declaration content to file. Handles the output path.
  *
- * @param path - Path to the original stylesheet file. NOT the path to write.
+ * @param file - Path to the original stylesheet file. NOT the path to write.
+ * @param outdir - Output directory to which to write.
  * @param ts - The TypeScript declaration content to write.
  * @returns Empty promise indicating when writing has completed.
  */
-async function writeDeclarationFile(path: string, ts: string | undefined) {
+async function writeDeclarationFile(
+	file: string,
+	outdir: string | undefined,
+	ts: string | undefined,
+) {
 	if (!ts) return undefined;
-	await writeFile(dtsPath(path), ts, `utf8`);
+	await writeFile(dtsPath(file, outdir), ts, `utf8`);
 	return undefined;
 }


### PR DESCRIPTION
Adds output directory option (`-o` or `--outdir`) as alternative to generating the declaration files alongside the source file.

Adds outdir unit test and pipeline test. Refactors pipeline tests to improve failure diagnosis.

+semver:minor