### PR TITLE
✨ Generate subcommand

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -88,45 +88,45 @@ jobs:
       - name: "Test 2: localsConvention, first position"
         if: success() || failure()
         run: |
-          scripts/test.sh casing/casing '' '--localsConvention camelCaseOnly *.css' casing/camelCaseOnly
+          scripts/test-gen.sh casing/casing '' '--localsConvention camelCaseOnly *.css' casing/camelCaseOnly
 
       - name: "Test 3: localsConvention, second position"
         if: success() || failure()
         run: |
-          scripts/test.sh casing/casing '' '*.css --localsConvention camelCaseOnly' casing/camelCaseOnly
+          scripts/test-gen.sh casing/casing '' '*.css --localsConvention camelCaseOnly' casing/camelCaseOnly
 
       - name: "Test 4: relative outdir"
         if: success() || failure()
         run: |
-          scripts/test.sh foo '' '--outdir generated *.css' '' generated/
+          scripts/test-gen.sh foo '' '--outdir generated *.css' '' generated/
 
       - name: "Test 5: absolute outdir"
         if: success() || failure()
         run: |
-          scripts/test.sh foo "" "-o $GITHUB_WORKSPACE/generated *.css" "" "$GITHUB_WORKSPACE"/generated/
+          scripts/test-gen.sh foo "" "-o $GITHUB_WORKSPACE/generated *.css" "" "$GITHUB_WORKSPACE"/generated/
         # Note: This test uses double quotes, which expands differently.
 
       - name: "Test 6: json file config"
         if: success() || failure()
         run: |
-          scripts/test.sh foo csstypedrc.json
+          scripts/test-gen.sh foo csstypedrc.json
 
       - name: "Test 7: yaml file config"
         if: success() || failure()
         run: |
-          scripts/test.sh foo csstypedrc.yaml '' '' generated/
+          scripts/test-gen.sh foo csstypedrc.yaml '' '' generated/
 
       - name: "Test 8: custom config path"
         if: success() || failure()
         run: |
-          scripts/test.sh foo css-typed-rc.yaml '-c .config/css-typed-rc.yaml'
+          scripts/test-gen.sh foo css-typed-rc.yaml '-c .config/css-typed-rc.yaml'
 
       - name: "Test 9: mjs file config"
         if: matrix.platform.os != 'windows' && (success() || failure())
         # Do not run on Windows due to Windows-only ESM import bug.
         # This _could_ be an issue with css-typed, but could be a test/deps issue.
         run: |
-          scripts/test.sh foo custom-config-path.config.mjs '-c .config/custom-config-path.config.mjs'
+          scripts/test-gen.sh foo custom-config-path.config.mjs '-c .config/custom-config-path.config.mjs'
 
   Publish:
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -78,50 +78,50 @@ jobs:
 
       - name: "Test 1: default case"
         run: |
-          scripts/test.sh foo '' '*.css'
+          scripts/test.sh '' foo '' '*.css'
 
       - name: "Test 2: localsConvention, first position"
         if: success() || failure()
         run: |
-          scripts/test.sh casing/casing '' '--localsConvention camelCaseOnly *.css' casing/camelCaseOnly
+          scripts/test.sh gen casing/casing '' '--localsConvention camelCaseOnly *.css' casing/camelCaseOnly
 
       - name: "Test 3: localsConvention, second position"
         if: success() || failure()
         run: |
-          scripts/test.sh casing/casing '' '*.css --localsConvention camelCaseOnly' casing/camelCaseOnly
+          scripts/test.sh gen casing/casing '' '*.css --localsConvention camelCaseOnly' casing/camelCaseOnly
 
       - name: "Test 4: relative outdir"
         if: success() || failure()
         run: |
-          scripts/test.sh foo '' '--outdir generated *.css' '' generated/
+          scripts/test.sh gen foo '' '--outdir generated *.css' '' generated/
 
       - name: "Test 5: absolute outdir"
         if: success() || failure()
         run: |
-          scripts/test.sh foo "" "-o $GITHUB_WORKSPACE/generated *.css" "" "$GITHUB_WORKSPACE"/generated/
+          scripts/test.sh gen foo "" "-o $GITHUB_WORKSPACE/generated *.css" "" "$GITHUB_WORKSPACE"/generated/
         # Note: This test uses double quotes, which expands differently.
 
       - name: "Test 6: json file config"
         if: success() || failure()
         run: |
-          scripts/test.sh foo csstypedrc.json
+          scripts/test.sh gen foo csstypedrc.json
 
       - name: "Test 7: yaml file config"
         if: success() || failure()
         run: |
-          scripts/test.sh foo csstypedrc.yaml '' '' generated/
+          scripts/test.sh gen foo csstypedrc.yaml '' '' generated/
 
       - name: "Test 8: custom config path"
         if: success() || failure()
         run: |
-          scripts/test.sh foo css-typed-rc.yaml '-c .config/css-typed-rc.yaml'
+          scripts/test.sh gen foo css-typed-rc.yaml '-c .config/css-typed-rc.yaml'
 
       - name: "Test 9: mjs file config"
         if: matrix.platform.os != 'windows' && (success() || failure())
         # Do not run on Windows due to Windows-only ESM import bug.
         # This _could_ be an issue with css-typed, but could be a test/deps issue.
         run: |
-          scripts/test.sh foo custom-config-path.config.mjs '-c .config/custom-config-path.config.mjs'
+          scripts/test.sh gen foo custom-config-path.config.mjs '-c .config/custom-config-path.config.mjs'
 
   Publish:
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -78,50 +78,55 @@ jobs:
 
       - name: "Test 1: default case"
         run: |
-          scripts/test.sh '' foo '' '*.css'
+          cp fixtures/foo.css $RUNNER_TEMP/test.css
+          cp fixtures/foo.d.css.ts $RUNNER_TEMP/expected.d.css.ts
+
+          cd $RUNNER_TEMP
+          $GITHUB_WORKSPACE/dist/main.js "*.css"
+          diff --color=always --strip-trailing-cr -uI "//.*" expected.d.css.ts test.d.css.ts
 
       - name: "Test 2: localsConvention, first position"
         if: success() || failure()
         run: |
-          scripts/test.sh gen casing/casing '' '--localsConvention camelCaseOnly *.css' casing/camelCaseOnly
+          scripts/test.sh casing/casing '' '--localsConvention camelCaseOnly *.css' casing/camelCaseOnly
 
       - name: "Test 3: localsConvention, second position"
         if: success() || failure()
         run: |
-          scripts/test.sh gen casing/casing '' '*.css --localsConvention camelCaseOnly' casing/camelCaseOnly
+          scripts/test.sh casing/casing '' '*.css --localsConvention camelCaseOnly' casing/camelCaseOnly
 
       - name: "Test 4: relative outdir"
         if: success() || failure()
         run: |
-          scripts/test.sh gen foo '' '--outdir generated *.css' '' generated/
+          scripts/test.sh foo '' '--outdir generated *.css' '' generated/
 
       - name: "Test 5: absolute outdir"
         if: success() || failure()
         run: |
-          scripts/test.sh gen foo "" "-o $GITHUB_WORKSPACE/generated *.css" "" "$GITHUB_WORKSPACE"/generated/
+          scripts/test.sh foo "" "-o $GITHUB_WORKSPACE/generated *.css" "" "$GITHUB_WORKSPACE"/generated/
         # Note: This test uses double quotes, which expands differently.
 
       - name: "Test 6: json file config"
         if: success() || failure()
         run: |
-          scripts/test.sh gen foo csstypedrc.json
+          scripts/test.sh foo csstypedrc.json
 
       - name: "Test 7: yaml file config"
         if: success() || failure()
         run: |
-          scripts/test.sh gen foo csstypedrc.yaml '' '' generated/
+          scripts/test.sh foo csstypedrc.yaml '' '' generated/
 
       - name: "Test 8: custom config path"
         if: success() || failure()
         run: |
-          scripts/test.sh gen foo css-typed-rc.yaml '-c .config/css-typed-rc.yaml'
+          scripts/test.sh foo css-typed-rc.yaml '-c .config/css-typed-rc.yaml'
 
       - name: "Test 9: mjs file config"
         if: matrix.platform.os != 'windows' && (success() || failure())
         # Do not run on Windows due to Windows-only ESM import bug.
         # This _could_ be an issue with css-typed, but could be a test/deps issue.
         run: |
-          scripts/test.sh gen foo custom-config-path.config.mjs '-c .config/custom-config-path.config.mjs'
+          scripts/test.sh foo custom-config-path.config.mjs '-c .config/custom-config-path.config.mjs'
 
   Publish:
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -53,11 +53,11 @@ jobs:
       matrix:
         node:
           - 20.x
-          - 22.x
+          #- 22.x
         platform:
           - os: ubuntu
-          - os: macos
-          - os: windows
+          #- os: macos
+          #- os: windows
       fail-fast: false
 
     steps:

--- a/scripts/test-gen.sh
+++ b/scripts/test-gen.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eo pipefail # Removed `-u` which failed on macos for `options`
+set -exo pipefail # Removed `-u` which failed on macos for `options`
 IFS=$' ' # We want space splitting for this script
 
 # $1 is the input name, relative to `fixtures`. Required.
@@ -32,8 +32,7 @@ pushd $RUNNER_TEMP > /dev/null || exit
 # `./dist/main.js` is executing local `css-typed` as if installed (same as `bin`).
 # But it is `$GITHUB_WORKSPACE/dist/main.js` b/c we `cd $RUNNER_TEMP`.
 echo "css-typed gen" "${options[@]}"
-# shellcheck disable=SC2068
-$GITHUB_WORKSPACE/dist/main.js gen ${options[@]}
+$GITHUB_WORKSPACE/dist/main.js gen "${options[@]}"
 
 # Use `diff` to compare the files.
 # Use `-I '//.*'` to ignore the first line (comment) which has generated path and timestamp.

--- a/scripts/test-gen.sh
+++ b/scripts/test-gen.sh
@@ -2,23 +2,20 @@
 set -eo pipefail # Removed `-u` which failed on macos for `options`
 IFS=$' ' # We want space splitting for this script
 
-# $1 is the subcommand to run
-subcommand=$1
+# $1 is the input name, relative to `fixtures`. Required.
+input=$1
 
-# $2 is the input name, relative to `fixtures`. Required.
-input=$2
+# $2 is the config file name, relative to `fixtures/config`. Defaults to $1.yaml.
+config=${2:-$1.yaml}
 
-# $3 is the config file name, relative to `fixtures/config`. Defaults to $2.yaml.
-config=${3:-$2.yaml}
+# $3 is the options. Defaults to "".
+read -r -a options <<< "${3:-}"
 
-# $4 is the options. Defaults to "".
-read -r -a options <<< "${4:-}"
+# $4 is the output name, relative to `fixtures`. Defaults to $1.
+output=${4:-$1}
 
-# $5 is the output name, relative to `fixtures`. Defaults to $1.
-output=${5:-$2}
-
-# $6 is the path prefix for output. Defaults to "".
-prefix=${6:-}
+# $5 is the path prefix for output. Defaults to "".
+prefix=${5:-}
 
 # Run from $RUNNER_TEMP for auto-cleanup.
 cp fixtures/${input}.css $RUNNER_TEMP/test.css
@@ -34,9 +31,9 @@ pushd $RUNNER_TEMP > /dev/null || exit
 
 # `./dist/main.js` is executing local `css-typed` as if installed (same as `bin`).
 # But it is `$GITHUB_WORKSPACE/dist/main.js` b/c we `cd $RUNNER_TEMP`.
-echo "css-typed ${subcommand}" "${options[@]}"
+echo "css-typed gen" "${options[@]}"
 # shellcheck disable=SC2068
-$GITHUB_WORKSPACE/dist/main.js ${subcommand} ${options[@]}
+$GITHUB_WORKSPACE/dist/main.js gen ${options[@]}
 
 # Use `diff` to compare the files.
 # Use `-I '//.*'` to ignore the first line (comment) which has generated path and timestamp.

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,20 +2,23 @@
 set -eo pipefail # Removed `-u` which failed on macos for `options`
 IFS=$' ' # We want space splitting for this script
 
-# $1 is the input name, relative to `fixtures`. Required.
-input=$1
+# $1 is the subcommand to run
+subcommand=$1
 
-# $2 is the config file name, relative to `fixtures/config`. Defaults to $1.yaml.
-config=${2:-$1.yaml}
+# $2 is the input name, relative to `fixtures`. Required.
+input=$2
 
-# $3 is the options. Defaults to "".
-read -r -a options <<< "${3:-}"
+# $3 is the config file name, relative to `fixtures/config`. Defaults to $2.yaml.
+config=${3:-$2.yaml}
 
-# $4 is the output name, relative to `fixtures`. Defaults to $1.
-output=${4:-$1}
+# $4 is the options. Defaults to "".
+read -r -a options <<< "${4:-}"
 
-# $5 is the path prefix for output. Defaults to "".
-prefix=${5:-}
+# $5 is the output name, relative to `fixtures`. Defaults to $1.
+output=${5:-$2}
+
+# $6 is the path prefix for output. Defaults to "".
+prefix=${6:-}
 
 # Run from $RUNNER_TEMP for auto-cleanup.
 cp fixtures/${input}.css $RUNNER_TEMP/test.css
@@ -31,9 +34,9 @@ pushd $RUNNER_TEMP > /dev/null || exit
 
 # `./dist/main.js` is executing local `css-typed` as if installed (same as `bin`).
 # But it is `$GITHUB_WORKSPACE/dist/main.js` b/c we `cd $RUNNER_TEMP`.
-echo "css-typed " "${options[@]}"
+echo "css-typed ${subcommand}" "${options[@]}"
 # shellcheck disable=SC2068
-$GITHUB_WORKSPACE/dist/main.js ${options[@]}
+$GITHUB_WORKSPACE/dist/main.js ${subcommand} ${options[@]}
 
 # Use `diff` to compare the files.
 # Use `-I '//.*'` to ignore the first line (comment) which has generated path and timestamp.

--- a/src/cli/command-utils.ts
+++ b/src/cli/command-utils.ts
@@ -42,6 +42,11 @@ function cssTypedAction(
 ) {
 	return this.action(
 		async (cliPattern, { config: cliConfigPath, ...cliOptions }, program) => {
+			console.debug(`[debug] CLI input:`, `pattern=${cliPattern}`, {
+				config: cliConfigPath,
+				...cliOptions,
+			});
+
 			// Load file configuration first
 			const configResult = await loadFileConfig(cliConfigPath);
 			if (configResult?.filepath) {

--- a/src/cli/command-utils.ts
+++ b/src/cli/command-utils.ts
@@ -60,6 +60,7 @@ function cssTypedAction(
 
 			// Resolve options from file config and CLI. CLI overrides file config.
 			const options: Options = { ...fileConfig, ...cliOptions };
+			console.debug(`[debug] Resolved options to`, options);
 
 			// Pattern is required. CLI overrides file config.
 			const pattern = cliPattern ?? filePattern;

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,8 +7,16 @@ import { version } from "./version.ts";
 await createCssTypedCommand()
 	.name(`css-typed`)
 	.description(
-		`TypeScript declaration generator for CSS files (and other stylesheets).`,
+		`TypeScript declaration generator for CSS files (and other stylesheets).\n\nRuns \`generate\` when no subcommand given.`,
 	)
 	.version(version)
 	.cssTypedAction(generate)
+	.helpCommand(`help [command]`, `Displays help for the given command.`)
+	.addCommand(
+		createCssTypedCommand()
+			.name(`gen`)
+			.alias(`generate`)
+			.description(`Generates TypeScript declaration files.`)
+			.cssTypedAction(generate),
+	)
 	.parseAsync();


### PR DESCRIPTION
Adds `gen` subcommand (aliased with `generate`). Preserves command-less invocation as generate.

Tweaks pipeline tests to allow for new `gen` subcommand.

semver:minor