### PR TITLE
➕ connorjs/github-workflows, use npm-ci-build

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -8,12 +8,14 @@ on:
 
 jobs:
   ci-build:
+    name: Build
     uses: connorjs/github-workflows/.github/workflows/npm-ci-build~v1.yaml@features/npm-ci-build
     with:
       project-type: Fail for testing
 
   pipeline-tests:
     name: Test (${{ matrix.node }} | ${{ matrix.platform.os }})
+    if: false
     defaults:
       run:
         shell: bash

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -7,43 +7,12 @@ on:
     branches: [main]
 
 jobs:
-  Build:
-    name: Build
-    runs-on: ubuntu-latest
-    outputs:
-      GitVersion_SemVer: ${{ steps.GitVersion.outputs.GitVersion_SemVer }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Full depth (not shallow) for GitVersion and better relevancy of Sonar analysis
+  ci-build:
+    uses: connorjs/github-workflows/.github/workflows/npm-ci-build@v1.yaml
+    with:
+      project-type: fail-for-testing
 
-      - name: Set up GitVersion
-        uses: gittools/actions/gitversion/setup@v2.0.1
-        with:
-          versionSpec: 6.x
-
-      - name: Execute GitVersion
-        id: GitVersion
-        uses: gittools/actions/gitversion/execute@v2.0.1
-        with:
-          overrideConfig: |
-            workflow=GitHubFlow/v1
-            mode=ContinuousDeployment
-
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          cache: npm
-          node-version-file: .node-version
-
-      - name: Install
-        run: npm ci
-
-      - name: CI build
-        run: npm run ci-build
-
-  Test:
+  pipeline-tests:
     name: Test (${{ matrix.node }} | ${{ matrix.platform.os }})
     defaults:
       run:
@@ -123,15 +92,15 @@ jobs:
         run: |
           scripts/test.sh foo custom-config-path.config.mjs '-c .config/custom-config-path.config.mjs'
 
-  Publish:
-    if: ${{ github.ref == 'refs/heads/main' }}
+  publish:
     name: Publish
+    if: ${{ github.ref == 'refs/heads/main' }}
     needs:
-      - Build # For version variable
-      - Test # Requires passing tests
+      - ci-build # For version variable
+      - pipeline-tests # Requires passing tests
     runs-on: ubuntu-latest
     env:
-      GitVersion_SemVer: ${{needs.Build.outputs.GitVersion_SemVer}}
+      semVer: ${{needs.ci-build.outputs.semVer}}
     permissions:
       contents: write
       id-token: write
@@ -145,7 +114,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Set version
-        run: sed -i 's/0.0.0-gitversion/${{ env.GitVersion_SemVer }}/g' package.json
+        run: sed -i 's/0.0.0-gitversion/${{ env.semVer }}/g' package.json
 
       - name: Install
         run: npm install
@@ -157,5 +126,5 @@ jobs:
 
       - name: git tag
         run: |
-          git tag v${{ env.GitVersion_SemVer }}
-          git push origin tag v${{ env.GitVersion_SemVer }}
+          git tag v${{ env.semVer }}
+          git push origin tag v${{ env.semVer }}

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   CiBuild:
     name: CI Build
-    uses: connorjs/github-workflows/.github/workflows/npm-ci-build~v1.yaml@features/npm-ci-build
+    uses: connorjs/github-workflows/.github/workflows/npm-ci-build~v1.yaml
 
   PipelineTests:
     name: Test (${{ matrix.node }} | ${{ matrix.platform.os }})

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ci-build:
-    uses: connorjs/github-workflows/.github/workflows/npm-ci-build@v1.yaml@features/npm-ci-build
+    uses: connorjs/github-workflows/.github/workflows/npm-ci-build~v1.yaml@features/npm-ci-build
     with:
       project-type: fail-for-testing
 

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -13,7 +13,6 @@ jobs:
 
   PipelineTests:
     name: Test (${{ matrix.node }} | ${{ matrix.platform.os }})
-    if: false
     defaults:
       run:
         shell: bash
@@ -94,7 +93,7 @@ jobs:
 
   Publish:
     name: Publish
-    if: ${{ github.ref == 'refs/heads/main' }}
+    # if: ${{ github.ref == 'refs/heads/main' }}
     needs:
       - CiBuild # For version variable
       - PipelineTests # Requires passing tests
@@ -117,14 +116,16 @@ jobs:
         run: sed -i 's/0.0.0-gitversion/${{ env.semVer }}/g' package.json
 
       - name: Install
-        run: npm install
+        run: npm ci
 
-      - name: Publish
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: git tag
-        run: |
-          git tag v${{ env.semVer }}
-          git push origin tag v${{ env.semVer }}
+      - name: Pack
+        run: npm pack
+#      - name: Publish
+#        run: npm publish --provenance --access public
+#        env:
+#          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+#
+#      - name: git tag
+#        run: |
+#          git tag v${{ env.semVer }}
+#          git push origin tag v${{ env.semVer }}

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ci-build:
-    name: Build
+    name: CI Build
     uses: connorjs/github-workflows/.github/workflows/npm-ci-build~v1.yaml@features/npm-ci-build
     with:
       project-type: Fail for testing

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -93,7 +93,7 @@ jobs:
 
   Publish:
     name: Publish
-    # if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     needs:
       - CiBuild # For version variable
       - PipelineTests # Requires passing tests
@@ -118,14 +118,12 @@ jobs:
       - name: Install
         run: npm ci
 
-      - name: Pack
-        run: npm pack
-#      - name: Publish
-#        run: npm publish --provenance --access public
-#        env:
-#          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-#
-#      - name: git tag
-#        run: |
-#          git tag v${{ env.semVer }}
-#          git push origin tag v${{ env.semVer }}
+      - name: Publish
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: git tag
+        run: |
+          git tag v${{ env.semVer }}
+          git push origin tag v${{ env.semVer }}

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -10,7 +10,7 @@ jobs:
   ci-build:
     uses: connorjs/github-workflows/.github/workflows/npm-ci-build~v1.yaml@features/npm-ci-build
     with:
-      project-type: fail-for-testing
+      project-type: Fail for testing
 
   pipeline-tests:
     name: Test (${{ matrix.node }} | ${{ matrix.platform.os }})

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ci-build:
-    uses: connorjs/github-workflows/.github/workflows/npm-ci-build@v1.yaml
+    uses: connorjs/github-workflows/.github/workflows/npm-ci-build@v1.yaml@features/npm-ci-build
     with:
       project-type: fail-for-testing
 

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -7,11 +7,11 @@ on:
     branches: [main]
 
 jobs:
-  ci-build:
+  CiBuild:
     name: CI Build
     uses: connorjs/github-workflows/.github/workflows/npm-ci-build~v1.yaml@features/npm-ci-build
 
-  pipeline-tests:
+  PipelineTests:
     name: Test (${{ matrix.node }} | ${{ matrix.platform.os }})
     if: false
     defaults:
@@ -92,15 +92,15 @@ jobs:
         run: |
           scripts/test.sh foo custom-config-path.config.mjs '-c .config/custom-config-path.config.mjs'
 
-  publish:
+  Publish:
     name: Publish
     if: ${{ github.ref == 'refs/heads/main' }}
     needs:
-      - ci-build # For version variable
-      - pipeline-tests # Requires passing tests
+      - CiBuild # For version variable
+      - PipelineTests # Requires passing tests
     runs-on: ubuntu-latest
     env:
-      semVer: ${{needs.ci-build.outputs.semVer}}
+      semVer: ${{needs.CiBuild.outputs.semVer}}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   CiBuild:
     name: CI Build
-    uses: connorjs/github-workflows/.github/workflows/npm-ci-build~v1.yaml
+    uses: connorjs/github-workflows/.github/workflows/npm-ci-build~v1.yaml@main
 
   PipelineTests:
     name: Test (${{ matrix.node }} | ${{ matrix.platform.os }})

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -10,8 +10,6 @@ jobs:
   ci-build:
     name: CI Build
     uses: connorjs/github-workflows/.github/workflows/npm-ci-build~v1.yaml@features/npm-ci-build
-    with:
-      project-type: Fail for testing
 
   pipeline-tests:
     name: Test (${{ matrix.node }} | ${{ matrix.platform.os }})


### PR DESCRIPTION
Replaces in-repo CI Build job with `npm-ci-build@v1` from `connorjs/github-worfklows`. Applies other changes to match published style conventions from that repo.

+semver:none