### PR TITLE
➕ connorjs/github-workflows, npm-publish

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -99,8 +99,10 @@ jobs:
 
     uses: connorjs/github-workflows/.github/workflows/npm-publish~v1.yaml@features/npm-pack-and-publish
     with:
-      npmPackFilename: ${{needs.CiBuild.outputs.npmPackFilename}}
-      semVer: ${{needs.CiBuild.outputs.semVer}}
+      npmPackFilename: ${{ needs.CiBuild.outputs.npmPackFilename }}
+      semVer: ${{ needs.CiBuild.outputs.semVer }}
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     permissions:
       contents: write

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch: {}
 
 jobs:
   CiBuild:

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   CiBuild:
     name: CI Build
-    uses: connorjs/github-workflows/.github/workflows/npm-ci-build~v1.yaml@features/npm-pack-and-publish
+    uses: connorjs/github-workflows/.github/workflows/npm-ci-build~v1.yaml@main
 
   PipelineTests:
     name: Test (${{ matrix.node }} | ${{ matrix.platform.os }})
@@ -97,7 +97,7 @@ jobs:
       - CiBuild # For version variable
       - PipelineTests # Requires passing tests
 
-    uses: connorjs/github-workflows/.github/workflows/npm-publish~v1.yaml@features/npm-pack-and-publish
+    uses: connorjs/github-workflows/.github/workflows/npm-publish~v1.yaml@main
     with:
       npmPackFilename: ${{ needs.CiBuild.outputs.npmPackFilename }}
       semVer: ${{ needs.CiBuild.outputs.semVer }}

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -9,7 +9,13 @@ on:
 jobs:
   CiBuild:
     name: CI Build
+
     uses: connorjs/github-workflows/.github/workflows/npm-ci-build~v1.yaml@features/npm-pack-and-publish
+
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
 
   PipelineTests:
     name: Test (${{ matrix.node }} | ${{ matrix.platform.os }})
@@ -101,3 +107,7 @@ jobs:
     with:
       npmPackFilename: ${{needs.CiBuild.outputs.npmPackFilename}}
       semVer: ${{needs.CiBuild.outputs.semVer}}
+
+    permissions:
+      contents: write
+      id-token: write

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -9,13 +9,7 @@ on:
 jobs:
   CiBuild:
     name: CI Build
-
     uses: connorjs/github-workflows/.github/workflows/npm-ci-build~v1.yaml@features/npm-pack-and-publish
-
-    permissions:
-      attestations: write
-      contents: read
-      id-token: write
 
   PipelineTests:
     name: Test (${{ matrix.node }} | ${{ matrix.platform.os }})

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   CiBuild:
     name: CI Build
-    uses: connorjs/github-workflows/.github/workflows/npm-ci-build~v1.yaml@main
+    uses: connorjs/github-workflows/.github/workflows/npm-ci-build~v1.yaml@features/npm-pack-and-publish
 
   PipelineTests:
     name: Test (${{ matrix.node }} | ${{ matrix.platform.os }})
@@ -93,37 +93,11 @@ jobs:
 
   Publish:
     name: Publish
-    if: ${{ github.ref == 'refs/heads/main' }}
     needs:
       - CiBuild # For version variable
       - PipelineTests # Requires passing tests
-    runs-on: ubuntu-latest
-    env:
+
+    uses: connorjs/github-workflows/.github/workflows/npm-publish~v1.yaml@features/npm-pack-and-publish
+    with:
+      npmPackFilename: ${{needs.CiBuild.outputs.npmPackFilename}}
       semVer: ${{needs.CiBuild.outputs.semVer}}
-    permissions:
-      contents: write
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          cache: npm
-          node-version-file: .node-version
-          registry-url: https://registry.npmjs.org
-
-      - name: Set version
-        run: sed -i 's/0.0.0-gitversion/${{ env.semVer }}/g' package.json
-
-      - name: Install
-        run: npm ci
-
-      - name: Publish
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: git tag
-        run: |
-          git tag v${{ env.semVer }}
-          git push origin tag v${{ env.semVer }}

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -5,7 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  workflow_dispatch: {}
 
 jobs:
   CiBuild:


### PR DESCRIPTION
Replaces in-repo Publish job with shared `npm-publish~v1`.

+semver:none