### PR TITLE
♻️ Run bin for pipeline tests

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -53,6 +53,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.CiBuild.outputs.npmPackFilename }}
+
       - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -14,7 +14,7 @@ jobs:
   Publish:
     name: Publish
     needs:
-      - CiBuild # For version variable
+      - CiBuild
       - PipelineTests # Requires passing tests
 
     uses: connorjs/github-workflows/.github/workflows/npm-publish~v1.yaml@main
@@ -30,10 +30,14 @@ jobs:
 
   PipelineTests:
     name: Test (${{ matrix.node }} | ${{ matrix.platform.os }})
+    needs:
+      - CiBuild
+
+    runs-on: ${{ matrix.platform.os }}-latest
     defaults:
       run:
         shell: bash
-    runs-on: ${{ matrix.platform.os }}-latest
+
     strategy:
       matrix:
         node:
@@ -55,11 +59,11 @@ jobs:
           cache: npm
           node-version: ${{ matrix.node }}
 
-      - name: Install
-        run: npm install
-
-      - name: Build
-        run: npm run build
+      - name: Install css-typed
+        run: |
+          mkdir -p sandbox
+          cd sandbox
+          npm install ${{ needs.CiBuild.outputs.npmPackFilename }}
 
       - name: "Test 1: default case"
         run: |
@@ -83,7 +87,7 @@ jobs:
       - name: "Test 5: absolute outdir"
         if: success() || failure()
         run: |
-          scripts/test.sh foo "" "-o $GITHUB_WORKSPACE/generated *.css" "" "$GITHUB_WORKSPACE"/generated/
+          scripts/test.sh foo "" "-o $RUNNER_TEMP/generated *.css" "" "$RUNNER_TEMP"/generated/
         # Note: This test uses double quotes, which expands differently.
 
       - name: "Test 6: json file config"

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -67,7 +67,7 @@ jobs:
         run: |
           mkdir -p sandbox
           cd sandbox
-          npm install ${{ needs.CiBuild.outputs.npmPackFilename }}
+          npm install ../${{ needs.CiBuild.outputs.npmPackFilename }}
 
       - name: "Test 1: default case"
         run: |

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -33,10 +33,12 @@ fi
 
 pushd $TEST_DIR > /dev/null || exit
 
-set -x
+set -x # Print the css-typed command exactly as executed
+
 # shellcheck disable=SC2068
 npx css-typed ${options[@]}
-set +x
+
+{ set +x; } 2>/dev/null # Turn off command printing, and do not print set +X
 
 # Use `diff` to compare the files.
 # Use `-I '//.*'` to ignore the first line (comment) which has generated path and timestamp.


### PR DESCRIPTION
Installs the packed `css-typed` package from CI Build into a sandbox for the pipeline tests and switches to using `npx css-typed`. This uses the actual `bin` entry point instead of emulating it with `node dist/main.js`.

In addition to matching the real world use case better, this ensures that we do not break the bin configuration again. (We broke in 0.5.0 release.)